### PR TITLE
fix description

### DIFF
--- a/pca9685_hardware_interface/include/pca9685_hardware_interface/Constants.h
+++ b/pca9685_hardware_interface/include/pca9685_hardware_interface/Constants.h
@@ -7,9 +7,6 @@ namespace PiPCA9685 {
 // Registers/etc:
 constexpr uint8_t MODE1              = 0x00;
 constexpr uint8_t MODE2              = 0x01;
-constexpr uint8_t SUBADR1            = 0x02;
-constexpr uint8_t SUBADR2            = 0x03;
-constexpr uint8_t SUBADR3            = 0x04;
 constexpr uint8_t PRESCALE           = 0xFE;
 constexpr uint8_t LED0_ON_L          = 0x06;
 constexpr uint8_t LED0_ON_H          = 0x07;
@@ -24,7 +21,6 @@ constexpr uint8_t ALL_LED_OFF_H      = 0xFD;
 constexpr uint8_t RESTART            = 0x80;
 constexpr uint8_t SLEEP              = 0x10;
 constexpr uint8_t ALLCALL            = 0x01;
-constexpr uint8_t INVRT              = 0x10;
 constexpr uint8_t OUTDRV             = 0x04;
 
 }  // namespace PiPCA9685

--- a/pca9685_hardware_interface/include/pca9685_hardware_interface/pca9685_system.hpp
+++ b/pca9685_hardware_interface/include/pca9685_hardware_interface/pca9685_system.hpp
@@ -28,7 +28,7 @@ public:
 
   PCA9685_HARDWARE_INTERFACE_PUBLIC
   hardware_interface::CallbackReturn on_init(
-    const hardware_interface::HardwareInfo & info) override;
+    const hardware_interface::HardwareComponentInterfaceParams & params) override;
 
   PCA9685_HARDWARE_INTERFACE_PUBLIC
   std::vector<hardware_interface::StateInterface> export_state_interfaces() override;

--- a/pca9685_hardware_interface/src/pca9685_system.cpp
+++ b/pca9685_hardware_interface/src/pca9685_system.cpp
@@ -15,13 +15,13 @@
 namespace pca9685_hardware_interface
 {
 hardware_interface::CallbackReturn Pca9685SystemHardware::on_init(
-  const hardware_interface::HardwareInfo & info)
+  const hardware_interface::HardwareComponentInterfaceParams & params)
 {
 
   pca.set_pwm_freq(50.0);
 
   if (
-    hardware_interface::SystemInterface::on_init(info) !=
+    hardware_interface::SystemInterface::on_init(params) !=
     hardware_interface::CallbackReturn::SUCCESS)
   {
     return hardware_interface::CallbackReturn::ERROR;

--- a/pca9685_hardware_interface/src/pca9685_system.cpp
+++ b/pca9685_hardware_interface/src/pca9685_system.cpp
@@ -58,7 +58,7 @@ hardware_interface::CallbackReturn Pca9685SystemHardware::on_init(
 std::vector<hardware_interface::StateInterface> Pca9685SystemHardware::export_state_interfaces()
 {
   std::vector<hardware_interface::StateInterface> state_interfaces;
-  
+
   for (auto i = 0u; i < info_.joints.size(); i++)
   {
     state_interfaces.emplace_back(hardware_interface::StateInterface(

--- a/pca9685_ros2_control_example/config/joint_group_velocity_controller.yaml
+++ b/pca9685_ros2_control_example/config/joint_group_velocity_controller.yaml
@@ -7,7 +7,10 @@ controller_manager:
 
 joint_group_velocity_controller:
   ros__parameters:
-    joints: 
-      - "joint_5"
+    joints:
+      - "joint_0"
+      - "joint_1"
+      - "joint_2"
+      - "joint_3"
       - "joint_4"
-  
+      - "joint_5"

--- a/pca9685_ros2_control_example/description/description.urdf.xacro
+++ b/pca9685_ros2_control_example/description/description.urdf.xacro
@@ -2,6 +2,23 @@
 
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="pca9685_example">
 
+  <xacro:macro name="link" params="id">
+    <link name="link_${id}"/>
+    <joint name="joint_${id}" type="continuous">
+      <parent link="base_link" />
+      <child link="link_${id}" />
+    </joint>
+  </xacro:macro>
+
+  <link name="base_link"/>
+
+  <xacro:link id="0"/>
+  <xacro:link id="1"/>
+  <xacro:link id="2"/>
+  <xacro:link id="3"/>
+  <xacro:link id="4"/>
+  <xacro:link id="5"/>
+
   <ros2_control name="pca9685_ros2_control_example" type="system">
     <hardware>
       <plugin>pca9685_hardware_interface/Pca9685SystemHardware</plugin>

--- a/pca9685_ros2_control_example/launch/joint_group_velocity_example.launch.py
+++ b/pca9685_ros2_control_example/launch/joint_group_velocity_example.launch.py
@@ -42,10 +42,17 @@ def generate_launch_description():
         ]
     )
 
+    robot_state_publisher_node = Node(
+        package='robot_state_publisher',
+        executable='robot_state_publisher',
+        parameters=[robot_description,],
+        output="both",
+    )
+
     control_node = Node(
         package="controller_manager",
         executable="ros2_control_node",
-        parameters=[robot_description, robot_controllers],
+        parameters=[robot_controllers],
         output="both",
     )
 
@@ -56,6 +63,7 @@ def generate_launch_description():
     )
 
     nodes = [
+        robot_state_publisher_node,
         control_node,
         robot_controller_spawner
     ]


### PR DESCRIPTION
The `ros2_control_node` does not take the robot description as `robot_description` anymore, but expects this to be published on the `/robot_description` topic.